### PR TITLE
Refactor Firestore saver

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,4 +1,14 @@
 {
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "checkpoints",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "thread_id", "mode": "ASCENDING" },
+        { "fieldPath": "checkpoint_ns", "mode": "ASCENDING" },
+        { "fieldPath": "checkpoint_id", "mode": "DESCENDING" }
+      ]
+    }
+  ],
   "fieldOverrides": []
 }


### PR DESCRIPTION
## Summary
- improve code readability and add error handling
- paginate checkpoint listing
- batch writes to Firestore
- define Firestore index for checkpoints
- update unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886e58bff1883248b0ef571186c3d9f