### PR TITLE
Refactor FirestoreSaver and add write batching

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,4 +1,15 @@
 {
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "checkpoints",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {"fieldPath": "thread_id", "order": "ASCENDING"},
+        {"fieldPath": "checkpoint_ns", "order": "ASCENDING"},
+        {"fieldPath": "metadata.step", "order": "ASCENDING"},
+        {"fieldPath": "checkpoint_id", "order": "DESCENDING"}
+      ]
+    }
+  ],
   "fieldOverrides": []
 }


### PR DESCRIPTION
## Summary
- improve variable names and error handling in `FirestoreSaver`
- use Firestore `WriteBatch` in `putWrites`
- add composite index config
- update unit tests for batching and add failure cases

## Testing
- `npm test` *(fails: download failed, status 403)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68870087fb148324afa77befafb69bc2